### PR TITLE
用real ip限制流量

### DIFF
--- a/cache-nginx/default.conf
+++ b/cache-nginx/default.conf
@@ -6,6 +6,8 @@ proxy_cache_path /cache levels=1:2
   keys_zone=suisiann_cache:10m max_size=20g use_temp_path=off
   inactive=1y;
 
+limit_req_zone $http_x_real_ip zone=ip:10m rate=3r/m;
+
 server {
   listen 80;
 
@@ -18,5 +20,7 @@ server {
     proxy_cache suisiann_cache;
     proxy_cache_valid 200 206 1d;
     proxy_cache_valid any 30s;
+
+    limit_req zone=ip burst=30 nodelay;
   }
 }

--- a/cache-nginx/default.conf
+++ b/cache-nginx/default.conf
@@ -6,7 +6,7 @@ proxy_cache_path /cache levels=1:2
   keys_zone=suisiann_cache:10m max_size=20g use_temp_path=off
   inactive=1y;
 
-limit_req_zone $http_x_real_ip zone=ip:10m rate=3r/m;
+limit_req_zone $http_x_real_ip zone=real_ip:10m rate=3r/m;
 
 server {
   listen 80;
@@ -21,6 +21,6 @@ server {
     proxy_cache_valid 200 206 1d;
     proxy_cache_valid any 30s;
 
-    limit_req zone=ip burst=30 nodelay;
+    limit_req zone=real_ip burst=30 nodelay;
   }
 }

--- a/hokbu-nginx/default.conf
+++ b/hokbu-nginx/default.conf
@@ -2,8 +2,6 @@ upstream backend {
   server hapsing:5000;
 }
 
-limit_req_zone $http_x_forwarded_for zone=ip:10m rate=3r/m;
-
 server {
   listen 80;
 
@@ -17,7 +15,5 @@ server {
     proxy_set_header Host $http_host;
     proxy_redirect off;
     proxy_pass http://backend;
-
-    limit_req zone=ip burst=30 nodelay;
   }
 }


### PR DESCRIPTION
因為 #2 希望鎖「人客IP」，本底 #4 設計會鎖tio̍h「cache-nginx IP」，造成 #5 問題。所以調整tī cache-nginx 鎖「人客IP」，架構圖：
![圖片](https://github.com/user-attachments/assets/45098c33-5419-451c-a25d-1d5290bfc877)

## 參考文件

- https://serverfault.com/a/487473
- https://github.com/nginx-proxy/nginx-proxy/tree/main/docs#headers
